### PR TITLE
Update Modal.swift

### DIFF
--- a/FlourishUI/FlourishUI/Modal.swift
+++ b/FlourishUI/FlourishUI/Modal.swift
@@ -151,9 +151,9 @@ public class Modal: UIViewController
     dialog.addSubview(dismissButton)
   }
   
-  convenience init(title: String?, body: String?, status: Status)
+  init(title: String?, body: String?, status: Status)
   {
-    self.init()
+    super.init()
     
     self.titleLabel.text = title
     self.bodyLabel.text = body


### PR DESCRIPTION
Changing convenience init to basic init to avoid compiler error with Xcode Version 6.2 (6C131e)
